### PR TITLE
Avatar changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ cython_debug/
 
 # Ignore openapi file while API not finished
 openapi.json
+
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install -r requirements.txt
 
 COPY . /llamalang/
 
-CMD ["./llamalang/run.sh"]
+CMD /bin/sh ./run.sh

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,12 +1,11 @@
 # serializers.py
 from django.db.models import Sum
-import base64
 from rest_framework import serializers
 
 from api.exceptions import LockedWordSetException
 from api.helpers import calculate_current_week_start
 from api.models import Translation, WordSet, MemoryGameSession, FallingWordsGameSession, CustomUser, ScoreHistory, \
-    Friendship, FriendRequest, TranslationUserAccuracyCounter, WordSetUserAccuracy
+    Friendship, FriendRequest, TranslationUserAccuracyCounter
 from djoser.serializers import UserCreateSerializer, UserSerializer
 
 
@@ -23,24 +22,13 @@ class TranslationUserAccuracyCounterSerializer(serializers.ModelSerializer):
 
 
 class CustomUserSerializer(UserSerializer):
-    avatar = serializers.SerializerMethodField()
-
     class Meta(UserSerializer.Meta):
         model = CustomUser
         read_only_fields = ('level', 'avatar')
         fields = ('id', 'username', 'level', 'avatar')
 
-    @staticmethod
-    def get_avatar(obj):
-        if obj.avatar:
-            with open(obj.avatar.path, "rb") as image_file:
-                image_data = base64.b64encode(image_file.read()).decode("utf-8")
-            return image_data
-        return None
-
 
 class MyProfileSerializer(serializers.ModelSerializer):
-    avatar = serializers.SerializerMethodField()
     current_week_points = serializers.SerializerMethodField()
     points_to_next_level = serializers.SerializerMethodField()
 
@@ -64,16 +52,6 @@ class MyProfileSerializer(serializers.ModelSerializer):
     @staticmethod
     def get_points_to_next_level(obj):
         return obj.get_points_to_next_level()
-
-    def get_avatar(self, obj):
-        request = self.context.get('request')
-        user = request.user
-
-        if user.avatar:
-            with open(user.avatar.path, "rb") as image_file:
-                image_data = base64.b64encode(image_file.read()).decode("utf-8")
-            return image_data
-        return None
 
 
 class TranslationSerializer(serializers.ModelSerializer):

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import os
 
-is_dev = os.environ.get("IS_DEV", 0) == 1
+is_dev = os.environ.get("IS_DEV", 0) == "1"
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -9,7 +9,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = (
     "django-insecure-5$z)v7nk!0y+!0f1=t3qwjn+u6y&byvc*o6z01lkf03=m&c9!j"
     if is_dev
-    else os.environ.get("IS_DEV")
+    else os.environ.get("SECRET_KEY")
 )
 DEBUG = is_dev
 

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -14,8 +14,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
+from django.conf.urls.static import static
 from rest_framework import routers
 from api import views
 
@@ -37,7 +39,7 @@ urlpatterns = [
     path("", include(router.urls)),
     path("statistics/", views.get_statistics),
     path("admin/", admin.site.urls),
-    path("avatar-upload/", views.UpdateProfileView.as_view(), name="avatar-upload"),
+    path("avatar-upload/", views.uploadAvatar, name="avatar-upload"),
     path("auth/", include("djoser.urls")),
     path("auth/", include("djoser.urls.authtoken")),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT, show_indexes=True)

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,6 @@ services:
   llamalang:
     image: llamalang
     build: ./
-    command: "/bin/sh /llamalang/run.sh"
     environment:
       IS_DEV: 1
       SQL_DATABASE: llamalang_db


### PR DESCRIPTION
Fixes avatar upload and makes them downloadable with an URL. Also has a corresponding PR in backend-tests. In the future we still need to add a S3 backend for production, but I think this is just replacing the default django storage with some existing S3 storage library and removing backend hosting the `media/folder`.

Also, this PR sneaks in a few changes for AWS deploy + gitignore for vscode configuration (I finally fixed the formatter on my end so I don't get 100 changes each time it's formatted).